### PR TITLE
The variable X can never match since previous clauses completely cove…

### DIFF
--- a/src/relflow_git.erl
+++ b/src/relflow_git.erl
@@ -56,9 +56,7 @@ appver_at_revision(Rev, Name, DirType) ->
         apps_dir ->
             fmt("git show ~s:apps/~s/src/~s.app.src", [Rev, Name, Name]);
         single_src_dir ->
-            fmt("git show ~s:src/~s.app.src", [Rev, Name]);
-        X ->
-                  throw({unhandled_dirtpe, X})
+            fmt("git show ~s:src/~s.app.src", [Rev, Name])
     end,
     Str = os:cmd(Cmd),
     {application, Name, AppOpts} = eval(Str),


### PR DESCRIPTION
…red the type 'apps_dir' | 'single_src_dir'